### PR TITLE
cuda-tools v12.9.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 # Ignore all files and folders in root
 *
 !/conda-forge.yml
+!/abs.yaml
 
 # Don't ignore any files/folders if the parent folder is 'un-ignored'
 # This also avoids warnings when adding an already-checked file with an ignored parent.

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,13 +10,13 @@ source:
 
 build:
   number: 0
-  skip: true  # [osx or ppc64le]
+  skip: true  # [osx]
 
 requirements:
   run:
     - cuda-command-line-tools {{ version }}
     - cuda-visual-tools {{ version }}
-    - gds-tools 1.14.1.1                     # [linux]
+    - gds-tools 1.14.1.1  # [linux]
 
 test:
   commands:
@@ -27,10 +27,12 @@ about:
   license_file: LICENSE.txt
   license: LicenseRef-NVIDIA-End-User-License-Agreement
   license_url: https://docs.nvidia.com/cuda/eula/index.html
+  license_family: Other
   summary: Meta-package containing all CUDA command line and visual tools.
   description: |
     Meta-package containing all CUDA command line and visual tools.
   doc_url: https://docs.nvidia.com/cuda/index.html
+  dev_url: https://docs.nvidia.com/cuda/index.html
 
 extra:
   recipe-maintainers:


### PR DESCRIPTION
cuda-tools 12.9.1

**Destination channel:** defaults

### Links

- [PKG-12808](https://anaconda.atlassian.net/browse/PKG-12808) 
- [CUDA 12.9 release notes](https://docs.nvidia.com/cuda/archive/12.9.1/cuda-toolkit-release-notes/index.html) for list of packages, version numbers, etc.
- Relevant dependency PRs:
  - https://github.com/AnacondaRecipes/cuda-command-line-tools-feedstock/pull/5

### Explanation of changes:

- CUDA 12.9 release
- Based on upstream feedstock's conda-forge/cuda-tools-feedstock@72824aa215529eb050852cd0eef854d5fb46969d commit.
- This is a meta-package

### Notes:

- PBP is injecting Python version to the tests and selecting the injected Python version randomly. In `cuda-tools` case, PBP selects Python 3.13 and one of the dependencies, `cuda-gdb=12.9` (and `gdb=14.2`) won't support Python 3.13. Therefore, the tests are failing. The PBP graph without the tests can be found [here](https://package-build.anaconda.com/v1/graph/d98078bb-3ef7-4ffa-a7e1-a3785dc0c876).

[PKG-12808]: https://anaconda.atlassian.net/browse/PKG-12808?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ